### PR TITLE
Updated NPM build scripts with cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "GPLv2",
   "private": true,
   "scripts": {
-    "dev": "WEBPACK_ENV=development webpack --progress --colors --watch --hide-modules",
-    "build": "WEBPACK_ENV=production webpack"
+    "dev": "cross-env WEBPACK_ENV=development webpack --progress --colors --watch --hide-modules",
+    "build": "cross-env WEBPACK_ENV=production webpack"
   },
   "dependencies": {
     "vue": "^2.5.2",
@@ -26,6 +26,7 @@
     "babel-runtime": "^6.26.0",
     "browser-sync": "^2.23.6",
     "browser-sync-webpack-plugin": "^2.0.1",
+    "cross-env": "^5.1.4",
     "css-loader": "^0.28.8",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",
@@ -37,6 +38,7 @@
     "vue-loader": "^13.7.0",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.13",
-    "webpack": "^3.10.0"
+    "webpack": "^3.11.0",
+    "webpack-cli": "^2.0.14"
   }
 }


### PR DESCRIPTION
The changes I've made here is to adjust for a bug I ran into while working on Windows.
 the scripts when running couldn't find WEBPACK_ENV which threw an error, so adding cross-env before the dev and build scripts made it work!