### PR TITLE
Moved call to includes to init_hooks so it fires on init, rather than…

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -140,7 +140,6 @@ final class Base_Plugin {
      * @return void
      */
     public function init_plugin() {
-        $this->includes();
         $this->init_hooks();
     }
 
@@ -201,6 +200,8 @@ final class Base_Plugin {
      * @return void
      */
     public function init_hooks() {
+
+        add_action( 'init', array( $this, 'includes') );
 
         add_action( 'init', array( $this, 'init_classes' ) );
 


### PR DESCRIPTION
This is an awesome project and really helped me get started while developing a few Vue plugins on a recent project. Thank you for all the work you put into this! At a certain point in my project, I started getting errors in the debug log stating that the App\Ajax class did not exist. I'm not sure why, but the request was not recognized as AJAX when the includes method was called during the plugins_loaded hook, so that file was not included. Moving includes so it fired during the init hook solved the issue and everything worked as expected. Init may be a more appropriate hook for this method anyways. I noticed in the README that you welcome contributions so I thought I'd go ahead and submit a PR. Please let me know if you have any questions. Thank you!